### PR TITLE
Fix paramHelp dependees: get dependencies from codyco-superbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,26 @@ compiler:
   - gcc
   - clang
 
+env:
+# set the CMAKE_PREFIX_PATH enviroment variable to get software installed by the superbuild
+  - TRAVIS_BUILD_TYPE=Debug, TRAVIS_CMAKE_GENERATOR="Unix Makefiles", CMAKE_PREFIX_PATH="/home/travis/build/robotology-playground/codyco-superbuild/build/install"
+  - TRAVIS_BUILD_TYPE=Release, TRAVIS_CMAKE_GENERATOR="Unix Makefiles", CMAKE_PREFIX_PATH="/home/travis/build/robotology-playground/codyco-superbuild/build/install"
+
+matrix:
+  allow_failures:
+    - compiler: clang
+
 install:
-  - sudo sh -c 'echo "deb http://www.icub.org/ubuntu precise contrib/science" > /etc/apt/sources.list.d/icub.list'
-  - sudo add-apt-repository -y ppa:kalakris/cmake
-  - sudo apt-get update
-  - sudo apt-get install cmake
+  # install dependencies using the codyco-superbuild script
+  - cd ..
+  - git clone https://github.com/robotology/codyco-superbuild
+  - cd codyco-superbuild
+  - chmod +x ./.ci/travis-deps.sh
+  - sh .ci/travis-deps.sh
 
 before_script:
   - cmake --version
-  - cd ..
   # use superbuild for getting paramHelp dependencies 
-  - git clone https://github.com/robotology/codyco-superbuild
-  - cd codyco-superbuild
   - mkdir build
   - cd build
   # using the YCM_EP_MAINTAINER_MODE variable to enable the subproject-dependees target 
@@ -23,16 +31,11 @@ before_script:
   - make paramHelp-dependees
   - pwd
   - cd ../..
-  # deal with TinyXML linking problems
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology-playground/codyco-superbuild/build/install/lib
-  - ls /home/travis/build/robotology-playground/codyco-superbuild/build/install/lib
-  - echo $LD_LIBRARY_PATH
-  - sudo ldconfig
   # Prepare paramHelp build
   - cd paramHelp
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=${PARAMHELP_TRAVIS_BUILD_TYPE} -DPARAMHELP_BUILD_TESTS:BOOL=ON  -DSTANDARD_FIND_MODULE_DEBUG:BOOL=ON ..
+  - cmake -DCMAKE_BUILD_TYPE=-DPARAMHELP_BUILD_TESTS:BOOL=ON  -DSTANDARD_FIND_MODULE_DEBUG:BOOL=ON ..
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,31 @@ install:
   - sudo sh -c 'echo "deb http://www.icub.org/ubuntu precise contrib/science" > /etc/apt/sources.list.d/icub.list'
   - sudo add-apt-repository -y ppa:kalakris/cmake
   - sudo apt-get update
-  - sudo apt-get --force-yes install yarp
   - sudo apt-get install cmake
 
 before_script:
   - cmake --version
   - cd ..
-  # Build and install YCM
-  - git clone https://github.com/robotology/ycm.git
-  - cd ycm
+  # use superbuild for getting paramHelp dependencies 
+  - git clone https://github.com/robotology/codyco-superbuild
+  - cd codyco-superbuild
   - mkdir build
   - cd build
-  - cmake ..
-  - make
-  - sudo make install
+  # using the YCM_EP_MAINTAINER_MODE variable to enable the subproject-dependees target 
+  - cmake -G"${TRAVIS_CMAKE_GENERATOR}" -DSTANDARD_FIND_MODULE_DEBUG:BOOL=ON -DCODYCO_TRAVIS_CI:BOOL=ON -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE} -DYCM_EP_MAINTAINER_MODE:BOOL=ON -DNON_INTERACTIVE_BUILD:BOOL=TRUE ..
+  - make paramHelp-dependees
+  - pwd
   - cd ../..
+  # deal with TinyXML linking problems
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology-playground/codyco-superbuild/build/install/lib
+  - ls /home/travis/build/robotology-playground/codyco-superbuild/build/install/lib
+  - echo $LD_LIBRARY_PATH
+  - sudo ldconfig
   # Prepare paramHelp build
   - cd paramHelp
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DCMAKE_BUILD_TYPE=${PARAMHELP_TRAVIS_BUILD_TYPE} -DPARAMHELP_BUILD_TESTS:BOOL=ON  -DSTANDARD_FIND_MODULE_DEBUG:BOOL=ON ..
 
 script:
   - make


### PR DESCRIPTION
After merge of pull request https://github.com/robotology-playground/paramHelp/pull/8 , the Travis build was failing due to paramHelp build dependencies:
- yInfo, yWarning debug YARP macros were not found by the compiler, while the required header <yarp/os/Log.h> was included.
This was due to a wrong version of YARP packages in the compiling process. Actually, the integration of each component dependencies (here YARP packages) is handled in the codyco-superbuild/libraries/paramHelp/.travis.yml file, where YARP was installed directly through apt-get.
The fix is directly based on https://github.com/robotology/codyco-superbuild/issues/49 (travis fix on all sub-projects). we rely on the superbuild for dealing with the paramHelp dependencies:
- we clone the codyco-superbuild  repo
- we set the YCM_EP_MAINTAINER_MODE mode
- we build the target paramHelp-dependees
